### PR TITLE
[RFC] For DOM children, use `repr(MIME("text/html", x))`

### DIFF
--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -244,7 +244,7 @@ renderdomchild(io, rctx::RenderContext, ctx::HTMLSVG, node::AbstractNode{HTMLSVG
 renderdomchild(io, rctx::RenderContext, ctx, x::Nothing) = nothing
 
 # Render and escape other HTMLSVG children, including CSS nodes, in the parent context.
-# renderdomchild(io, rctx::RenderContext, ctx, x) = printescaped(io, x, escapechild(ctx))
+# If a child is `showable` with text/html, render with that using `repr`.
 renderdomchild(io, rctx::RenderContext, ctx, x) = 
     showable(MIME("text/html"), x) ? print(io, repr(MIME("text/html"), x)) : printescaped(io, x, escapechild(ctx))
 

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -244,7 +244,9 @@ renderdomchild(io, rctx::RenderContext, ctx::HTMLSVG, node::AbstractNode{HTMLSVG
 renderdomchild(io, rctx::RenderContext, ctx, x::Nothing) = nothing
 
 # Render and escape other HTMLSVG children, including CSS nodes, in the parent context.
-renderdomchild(io, rctx::RenderContext, ctx, x) = printescaped(io, x, escapechild(ctx))
+# renderdomchild(io, rctx::RenderContext, ctx, x) = printescaped(io, x, escapechild(ctx))
+renderdomchild(io, rctx::RenderContext, ctx, x) = 
+    showable(MIME("text/html"), x) ? print(io, repr(MIME("text/html"), x)) : printescaped(io, x, escapechild(ctx))
 
 # All camelCase attribute names from HTML 4, HTML 5, SVG 1.1, SVG Tiny 1.2, and SVG 2
 const HTML_SVG_CAMELS = Dict(lowercase(x) => x for x in [


### PR DESCRIPTION
With this change, HTML content can be nested inside `Node`'s. This means a package user can include Markdown inside a node and have the HTML representation of that embedded. Likewise, a DataFrame will have its HTML representation included. Here is an example:

```julia
julia> using Hyperscript, Markdown

julia> m("div", md"# *Important* heading")
<div><div class="markdown"><h1><em>Important</em> heading</h1>
</div></div>
```

I'm not sure what the impact is on escaping. This branch passes tests locally.