### PR TITLE
Use `show` instead of `repr`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 .DS_Store
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,8 @@ uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
 author = ["Yuri Vishnevsky <yurivish@gmail.com>"]
 version = "0.0.4"
 
-[compat]
-julia = "1"
-
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+julia = "1"

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -238,7 +238,7 @@ renderdomchild(io, rctx::RenderContext, ctx, x::Nothing) = nothing
 # Render and escape other HTMLSVG children, including CSS nodes, in the parent context.
 # If a child is `showable` with text/html, render with that using `repr`.
 renderdomchild(io, rctx::RenderContext, ctx, x) = 
-    showable(MIME("text/html"), x) ? print(io, repr(MIME("text/html"), x)) : printescaped(io, x, escapechild(ctx))
+    showable(MIME("text/html"), x) ? show(io, MIME("text/html"), x) : printescaped(io, x, escapechild(ctx))
 
 # All camelCase attribute names from HTML 4, HTML 5, SVG 1.1, SVG Tiny 1.2, and SVG 2
 const HTML_SVG_CAMELS = Dict(lowercase(x) => x for x in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,3 +278,18 @@ import Hyperscript: px, em
 @test string(5 * (1px + 2em)) == "calc(5 * (1px + 2em))"
 @test string(5 * (1px + 3px + 4.3em)) == "calc(5 * (4px + 4.3em))"
 @test string(3.2 * (4.3em + 1px + 3px)) == "calc(3.2 * ((4.3em + 1px) + 3px))"
+
+# IOContext passthrough.
+struct MyType
+end
+Base.show(io::IO, ::MIME"text/html", ::MyType) = print(io, get(io, :key, ""))
+
+let
+    io = IOBuffer()
+    show(io, MIME("text/html"), m("div")(MyType()))
+    @test String(take!(io)) == "<div></div>"
+
+    ctx = IOContext(io, :key => "value")
+    show(ctx, MIME("text/html"), m("div")(MyType()))
+    @test String(take!(io)) == "<div>value</div>"
+end


### PR DESCRIPTION
Allows for passing `IOContext` through to underlying `show` methods for arbitary types embedded in the dom. This doesn't appear to cause any tests to fail, but given the direct reference to `repr` in the comment above this method I'm not 100% whether the fix here does actually cause issues, though I'd assume it wouldn't...

Some context for the issue: I've got types embedded in hyperscript dom elements where their `show` methods depend on information carried through in an `IOContext`, using `repr` here discards the context.
