### PR TITLE
Add support for a do-block syntax

### DIFF
--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -335,6 +335,11 @@ const NOESCAPE_HTMLSVG_CONTEXT = HTMLSVG(false, true)
 m(tag::AbstractString, cs...; as...) = Node(DEFAULT_HTMLSVG_CONTEXT, tag, cs, as)
 m(ctx::Context, tag::AbstractString, cs...; as...) = Node(ctx, tag, cs, as)
 
+# Do block syntax
+Node(f::Function, ctx::T, tag::AbstractString, children, attrs) where T <: Context = Node(ctx, tag, [children..., f()], attrs)
+(x::Node)(f::Function, cs...; as...) = x(cs..., f(); as...)
+m(f::Function, args...; as...) = m(args..., f(); as...)
+
 # HTML/SVG tags macros
 macro tags(args::Symbol...)
     blk = Expr(:block)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,6 +189,52 @@ end
 # Dot syntax with regular class specification as an override
 @renders m("p", class="a")(class="b") s`<p class="b"></p>`
 
+# Do block syntax for Node application
+@renders p() do
+end s`<p></p>`
+@renders p() do
+    "child"
+end s`<p>child</p>`
+@renders p("child1") do
+    "child2"
+end s`<p>child1child2</p>`
+# Do block syntax for m
+@renders m("p") do
+end s`<p></p>`
+@renders m("p") do
+    "child"
+end s`<p>child</p>`
+@renders m("p", "child1") do
+    "child2"
+end s`<p>child1child2</p>`
+# Do block syntax for Node
+@renders Hyperscript.Node(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, "p", [], []) do
+end s`<p></p>`
+@renders Hyperscript.Node(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, "p", [], []) do
+    "child"
+end s`<p>child</p>`
+@renders Hyperscript.Node(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, "p", ["child1"], []) do
+    "child2"
+end s`<p>child1child2</p>`
+# Do block syntax with attributes
+@renders m("p", class="a") do
+end s`<p class="a"></p>`
+@renders m("p", class="a") do
+    "child"
+end s`<p class="a">child</p>`
+@renders m("p", "child1", class="a") do
+    "child2"
+end s`<p class="a">child1child2</p>`
+# Do block syntax with dot syntax
+@renders m("p").a() do
+end s`<p class="a"></p>`
+@renders m("p").a() do
+    "child"
+end s`<p class="a">child</p>`
+@renders m("p").a("child1") do
+    "child2"
+end s`<p class="a">child1child2</p>`
+
 ## CSS nodes
 # Tags must be strings
 @renders css("p") s`p {}`


### PR DESCRIPTION
This adds the proposed in #32:

```julia
julia> using Hyperscript

julia> @tags p

julia> p() do
           "child"
       end
<p>child</p>

julia> m("p") do
           "child"
       end
<p>child</p>
```